### PR TITLE
Relax constraints on FilePathBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Hyperparameters"
 uuid = "dec02a44-0573-464b-9dcd-b0da4b5d2d2e"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 
 [compat]
-FilePathsBase = "0.6, 0.7, 0.8"
+FilePathsBase = "0.6, 0.7, 0.8, 0.9"
 JSON = "0.21"
 Memento = "0.11, 0.12, 0.13, 1"
 julia = "1"


### PR DESCRIPTION
This package barely uses the FilePathsBase API, and should still be compatible with the 0.9