### PR TITLE
Allow saving of local variables to HYPERPARAMETERS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Hyperparameters"
 uuid = "dec02a44-0573-464b-9dcd-b0da4b5d2d2e"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"

--- a/src/Hyperparameters.jl
+++ b/src/Hyperparameters.jl
@@ -4,7 +4,7 @@ using FilePathsBase: AbstractPath, /
 using JSON
 using Memento
 
-export HYPERPARAMETERS, hyperparam, hyperparams, report_hyperparameters
+export HYPERPARAMETERS, hyperparam, hyperparams, report_hyperparameters, save_hyperparam
 
 const MODULE = @__MODULE__
 const LOGGER = getlogger(MODULE)
@@ -20,7 +20,7 @@ const SAGEMAKER_PREFIX = "SM_HP_"
 # Grabs hyperparameter from environment variables
 _get_hyperparam(name::Symbol, prefix::AbstractString)= ENV[uppercase(string(prefix, name))]
 
-# Records a hyper-parameter into global HYPERPARAMETERS dict for later reporting
+# Records a hyperparameter into global HYPERPARAMETERS dict for later reporting
 # Logs if a hyperparameter is set twice to two difference values
 function _set_hyperparam(name::Symbol, value)
     if haskey(HYPERPARAMETERS, name)
@@ -40,7 +40,7 @@ end
 """
     hyperparam([T::Type=Float64,] name; prefix="$SAGEMAKER_PREFIX"))
 
-Load the hyperparameter with the given `name` from the enviroment variable
+Load the hyperparameter with the given `name` from the environment variable
 named with the name in uppercase, and prefixed with `prefix`
 parsing it as type `T` (default: `Float64`).
 
@@ -101,6 +101,16 @@ function hyperparams(
     end
 
     return (; parameters...)
+end
+
+"""
+    save_hyperparam(name::Symbol, value, prefix::AbstractString="")
+
+Save value to the enviroment variables and the global `HYPERPARAMETERS` dictionary.
+"""
+function save_hyperparam(name::Symbol, value; prefix::AbstractString="")
+    ENV[uppercase(string(prefix, name))] = string(value)
+    _set_hyperparam(name, value)
 end
 
 """

--- a/test/hyperparameters.jl
+++ b/test/hyperparameters.jl
@@ -53,6 +53,11 @@
         @test hp.hpa isa Int
         @test HYPERPARAMETERS == Dict(:hpa => 1, :hpb => "2", :hpc => 3)
         @test HYPERPARAMETERS[:hpa] isa Int
+
+        save_hyperparam(:hpd, 4, prefix="OTHER_")
+        @test HYPERPARAMETERS[:hpd] isa Int
+        @test HYPERPARAMETERS[:hpd] == 4
+        @test ENV["OTHER_HPD"] == "4"
     end
 
     @testset "report_hyperparameters" begin


### PR DESCRIPTION
There is a situation in our code where we would like to report a local variable along with the hyperparameters. 