### PR TITLE
Read from Enviroment variables for report

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Hyperparameters"
 uuid = "dec02a44-0573-464b-9dcd-b0da4b5d2d2e"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"

--- a/src/Hyperparameters.jl
+++ b/src/Hyperparameters.jl
@@ -20,7 +20,7 @@ const SAGEMAKER_PREFIX = "SM_HP_"
 
 _name_to_envvar(prefix, name) = uppercase(string(prefix, name))
 function _envvar_to_name(prefix, name)
-    startswith(name, prefix) || throw(DomainError(name, "should have prefix; $prefix"))
+    startswith(name, prefix) || throw(DomainError(name, "Should have prefix; $prefix"))
     return Symbol(lowercase(SubString(name, length(prefix) + 1)))
 end
 

--- a/test/hyperparameters.jl
+++ b/test/hyperparameters.jl
@@ -63,14 +63,22 @@
     @testset "report_hyperparameters" begin
         # Ensure hyperparameters are what we expect
         empty!(HYPERPARAMETERS)
-        push!(HYPERPARAMETERS, :hpa => 1.0, :hpb => "2", :hpc => 3)
 
-        mktmpdir() do dir
-            @test_log LOGGER "info" "hyperparameters: hpb=2" report_hyperparameters(dir)
-            contents = read(joinpath(dir, "hyperparameters.json"), String)
-            @test occursin("\"hpb\": \"2\"", contents)
-            @test occursin("\"hpa\": 1.0", contents)
-            @test occursin("\"hpc\": 3", contents)
+        withenv("SM_HP_HPA" => "1", "SM_HP_HPB" => "2", "SM_HP_HPC" => "3") do
+            # we use hpa and hpb, but we hwant hpc to just be scoped from environment
+            # might not be as good as reading it so it knows the type, but better than losing it.
+            hyperparam(:hpa)
+            hyperparam(String, :hpb)
+
+            mktmpdir() do dir
+                @test_log LOGGER "info" "hyperparameters: hpb=2" report_hyperparameters(dir)
+
+                contents = read(joinpath(dir, "hyperparameters.json"), String)
+                @test occursin("\"hpa\": 1.0", contents)
+                @test occursin("\"hpb\": \"2\"", contents)
+                @test occursin("\"hpc\": \"3\"", contents)  # unused so is a string
+            end
         end
     end
+
 end

--- a/test/hyperparameters.jl
+++ b/test/hyperparameters.jl
@@ -65,7 +65,7 @@
         empty!(HYPERPARAMETERS)
 
         withenv("SM_HP_HPA" => "1", "SM_HP_HPB" => "2", "SM_HP_HPC" => "3") do
-            # we use hpa and hpb, but we hwant hpc to just be scoped from environment
+            # we use hpa and hpb, but we want hpc to just be scoped from environment
             # might not be as good as reading it so it knows the type, but better than losing it.
             hyperparam(:hpa)
             hyperparam(String, :hpb)


### PR DESCRIPTION
It's not super elegant, it just mashed the dictionaries together, and says that anything unused is a string.
But it is better than losing them.

Closes #10